### PR TITLE
Updated Some Authorities URL on horizon_xml.rb

### DIFF
--- a/lib/horizon_xml.rb
+++ b/lib/horizon_xml.rb
@@ -17,12 +17,12 @@ module HorizonXml
     },
     cowra: {
       start_url:
-        "http://myhorizon.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap_cowra",
+        "https://mycouncil.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap_cowra#/home",
       state: "NSW"
     },
     liverpool_plains: {
       start_url:
-        "http://myhorizon.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap_lpsc",
+        "https://mycouncil.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap_lpsc#/home",
       state: "NSW"
     },
     walcha: {
@@ -31,7 +31,7 @@ module HorizonXml
       state: "NSW"
     },
     weddin: {
-      start_url: "http://myhorizon.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap",
+      start_url: "https://mycouncil.solorient.com.au/Horizon/logonGuest.aw?domain=horizondap_weddin#/home",
       state: "NSW"
     },
     maitland: {


### PR DESCRIPTION
The URL for Cowra, Liverpool plains and Weddin were obsolete. So I updated them with the correct URLs.

This fixes issues #450, #447 and  #446.